### PR TITLE
修正帳戶原則檢查邏輯（範圍/門檻比對）並複核 TWGCB-01-010 基準版本

### DIFF
--- a/GCB_for_windows11.ps1
+++ b/GCB_for_windows11.ps1
@@ -1,5 +1,5 @@
 # GCB Windows 11 Checker and Setter Script
-# Version 1.0
+# Version 1.1
 # Author: warden
 #
 # DISCLAIMER: This script modifies system security settings.
@@ -80,7 +80,7 @@ Function Check-Set-RegistryValue {
             New-Item -Path $Path -Force -ErrorAction Stop | Out-Null
         }
         $currentValue = (Get-ItemProperty -Path $Path -Name $Name -ErrorAction SilentlyContinue).$Name
-        
+
         if ($currentValue -eq $ExpectedValue) {
             Write-Log "Result: '$Name' is already compliant. (Value: $currentValue)" -Status "COMPLIANT"
         } else {
@@ -99,18 +99,37 @@ Function Check-Set-RegistryValue {
 }
 
 # Function to check and set Local Security Policy values (Account Policies)
+#
+# Comparison modes (GCB account-policy requirements are ranges/thresholds, not exact values):
+#   Equal         : current must equal $ExpectedValue (default; use for on/off toggles)
+#   AtLeast       : current must be >= $ExpectedValue (e.g. 最小密碼長度、密碼最短使用期限)
+#   AtMostNonZero : current must be > 0 AND <= $ExpectedValue (e.g. 密碼最長使用期限、帳戶鎖定閾值,
+#                   where 0 has the special meaning "never expires" / "never locked out" and must
+#                   itself be treated as NON-COMPLIANT)
+#
+# NOTE (bug fix): this function previously compared with a strict "-eq $ExpectedValue" for every
+# policy. Because TWGCB-01-010 account-policy items are actually ranges/thresholds (e.g. "password
+# length >= 8"), that exact-match logic produced false-positive NON-COMPLIANT findings whenever the
+# current value was already stricter than the threshold (e.g. a configured password length of 14
+# was flagged non-compliant against an ExpectedValue of 8), and remediation would then WEAKEN an
+# already-compliant, stricter setting down to the bare threshold. The -Comparison parameter fixes
+# this: when non-compliant, remediation still writes $ExpectedValue (the GCB threshold), which is
+# correct in both directions (raises a too-weak value to the threshold, and no longer touches a
+# value that is already at or beyond the threshold).
 Function Check-Set-SecurityPolicy {
     param (
         [Parameter(Mandatory=$true)] [string]$PolicyName,
         [Parameter(Mandatory=$true)] [int]$ExpectedValue,
-        [Parameter(Mandatory=$true)] [string]$Description
+        [Parameter(Mandatory=$true)] [string]$Description,
+        [ValidateSet("Equal", "AtLeast", "AtMostNonZero")]
+        [string]$Comparison = "Equal"
     )
-    Write-Log "Checking: $Description" -Status "INFO"
-    
+    Write-Log "Checking: $Description (rule: $Comparison $ExpectedValue)" -Status "INFO"
+
     # Export current settings
     secedit /export /cfg $SecEditExportFile /quiet
     $content = Get-Content $SecEditExportFile
-    
+
     $currentValueLine = $content | Select-String -Pattern "^$PolicyName\s*=" -CaseSensitive
     if ($currentValueLine) {
         $currentValue = ($currentValueLine -split "=")[1].Trim()
@@ -118,10 +137,22 @@ Function Check-Set-SecurityPolicy {
         $currentValue = "Not Found"
     }
 
-    if ($currentValue -eq $ExpectedValue) {
+    # Evaluate compliance according to the comparison mode (range/threshold, not exact match).
+    $isCompliant = $false
+    $currentInt = 0
+    $isNumeric = [int]::TryParse([string]$currentValue, [ref]$currentInt)
+    if ($isNumeric) {
+        switch ($Comparison) {
+            "AtLeast"       { $isCompliant = ($currentInt -ge $ExpectedValue) }
+            "AtMostNonZero" { $isCompliant = ($currentInt -gt 0 -and $currentInt -le $ExpectedValue) }
+            default         { $isCompliant = ($currentInt -eq $ExpectedValue) }
+        }
+    }
+
+    if ($isCompliant) {
         Write-Log "Result: '$PolicyName' is already compliant. (Value: $currentValue)" -Status "COMPLIANT"
     } else {
-        Write-Log "Result: '$PolicyName' is NON-COMPLIANT. (Current: '$currentValue', Expected: '$ExpectedValue')" -Status "FAILURE"
+        Write-Log "Result: '$PolicyName' is NON-COMPLIANT. (Current: '$currentValue', Required: '$Comparison $ExpectedValue')" -Status "FAILURE"
         try {
             # Create an import file with only the required change
             "[System Access]`n$PolicyName = $ExpectedValue" | Out-File $SecEditImportFile -Encoding "Unicode"
@@ -177,23 +208,20 @@ Write-Log "================= Starting GCB Checks =================" -Status "INF
 # --- 帳戶原則 (Account Policies) ---
 Write-Log "Section: Account Policies" -Status "INFO"
 
-# TWGCB-01-010-0001: 密碼最短使用期限 (1天)
-Check-Set-SecurityPolicy -PolicyName "MinimumPasswordAge" -ExpectedValue 1 -Description "密碼最短使用期限"
+# TWGCB-01-010-0001: 密碼最短使用期限 (1天以上) -> compliant when current >= 1
+Check-Set-SecurityPolicy -PolicyName "MinimumPasswordAge" -ExpectedValue 1 -Comparison AtLeast -Description "密碼最短使用期限"
 
-# TWGCB-01-010-0002: 密碼最長使用期限 (90天以下)
-# This check is complex (less than 90). Script will enforce 90.
-Check-Set-SecurityPolicy -PolicyName "MaximumPasswordAge" -ExpectedValue 90 -Description "密碼最長使用期限"
+# TWGCB-01-010-0002: 密碼最長使用期限 (1~90天，不可為0/永不過期) -> compliant when 0 < current <= 90
+Check-Set-SecurityPolicy -PolicyName "MaximumPasswordAge" -ExpectedValue 90 -Comparison AtMostNonZero -Description "密碼最長使用期限"
 
-# TWGCB-01-010-0003: 最小密碼長度 (8個字元以上)
-# This check is complex (greater than 8). Script will enforce 8.
-Check-Set-SecurityPolicy -PolicyName "MinimumPasswordLength" -ExpectedValue 8 -Description "最小密碼長度"
+# TWGCB-01-010-0003: 最小密碼長度 (8個字元以上) -> compliant when current >= 8 (stricter existing values are kept)
+Check-Set-SecurityPolicy -PolicyName "MinimumPasswordLength" -ExpectedValue 8 -Comparison AtLeast -Description "最小密碼長度"
 
-# TWGCB-01-010-0004: 密碼必須符合複雜性需求 (啟用)
-Check-Set-SecurityPolicy -PolicyName "PasswordComplexity" -ExpectedValue 1 -Description "密碼必須符合複雜性需求"
+# TWGCB-01-010-0004: 密碼必須符合複雜性需求 (啟用) -> boolean toggle, exact match is correct
+Check-Set-SecurityPolicy -PolicyName "PasswordComplexity" -ExpectedValue 1 -Comparison Equal -Description "密碼必須符合複雜性需求"
 
-# TWGCB-01-010-0007: 帳戶鎖定閾值 (5次以下)
-# This check is complex (less than 5). Script will enforce 5.
-Check-Set-SecurityPolicy -PolicyName "LockoutBadCount" -ExpectedValue 5 -Description "帳戶鎖定閾值"
+# TWGCB-01-010-0007: 帳戶鎖定閾值 (1~5次，不可為0/永不鎖定) -> compliant when 0 < current <= 5
+Check-Set-SecurityPolicy -PolicyName "LockoutBadCount" -ExpectedValue 5 -Comparison AtMostNonZero -Description "帳戶鎖定閾值"
 
 
 # --- 電腦設定\系統管理範本 (Computer Settings - Administrative Templates) ---

--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@
     ```powershell
     # TWGCB-01-010-0009: 帳戶鎖定期間 (15分鐘以上)
     # Script enforces 15 minutes
-    Check-Set-SecurityPolicy -PolicyName "LockoutDuration" -ExpectedValue 15 -Description "帳戶鎖定期間"
+    Check-Set-SecurityPolicy -PolicyName "LockoutDuration" -ExpectedValue 15 -Comparison AtLeast -Description "帳戶鎖定期間"
     ```
 * `PolicyName` 需對應 `.inf` 設定檔中的關鍵字，常見的對應可參考網路文件或匯出的 `$env:temp\secedit_export.inf` 檔案。
+* `-Comparison` 參數請依該項目的實際規則語意選擇 `Equal`（固定值/開關）、`AtLeast`（下限，數值需大於等於門檻）或 `AtMostNonZero`（上限且不可為 0，數值需大於 0 且小於等於門檻）；詳見下方「變更紀錄」。
 
 ### 2. 系統管理範本設定 (使用登錄檔)
 
@@ -121,7 +122,31 @@
 ## 參考文件
 
 * **政府組態基準 (GCB) 文件**: `TWGCB-01-010_Microsoft Windows 11政府組態基準說明文件v1.0_1121201.pdf` 
+* **目前採用版本**：TWGCB-01-010 **v1.0**（中華民國112年12月1日 / 1121201）。截至 2026-07-17，經複核未發現官方已發布更新版本，詳見下方「變更紀錄」。
 
+## 變更紀錄
+
+* **2026-07-17**：修正帳戶原則檢查的比對邏輯錯誤，並複核目前基準版本。
+    * **邏輯修正（Bug fix）**：`Check-Set-SecurityPolicy` 先前一律以完全相等 (`-eq`) 判斷帳戶原則是否合規，但 TWGCB-01-010 對應的帳戶原則項目實際規定為「範圍／門檻」而非單一固定值。這導致：
+        1. 已符合、甚至**更嚴格**的既有設定（例如最小密碼長度已設為 14、帳戶鎖定閾值已設為 3）被誤判為 `NON-COMPLIANT`；
+        2. 觸發修正動作後，反而把原本更嚴格的設定**弱化**至門檻值（例如密碼長度 14 → 8）；
+        3. 未正確判斷「0」在部分項目中代表「永不過期／永不鎖定」的不合規特殊值。
+
+      修正方式：為 `Check-Set-SecurityPolicy` 新增 `-Comparison` 參數（`Equal` / `AtLeast` / `AtMostNonZero`），並依各項目的正確規則語意套用：
+
+      | TWGCB-ID | 項目 | 規則語意 | 修正前 | 修正後 (`-Comparison`) |
+      |---|---|---|---|---|
+      | 0001 | 密碼最短使用期限 | ≥ 1 天 | `-eq 1` | `AtLeast 1` |
+      | 0002 | 密碼最長使用期限 | 1~90 天（不可為 0/永不過期） | `-eq 90` | `AtMostNonZero 90` |
+      | 0003 | 最小密碼長度 | ≥ 8 字元（保留既有更嚴格設定） | `-eq 8` | `AtLeast 8` |
+      | 0004 | 密碼必須符合複雜性需求 | 啟用（布林開關，維持精確比對） | `-eq 1` | `Equal 1`（行為不變） |
+      | 0007 | 帳戶鎖定閾值 | 1~5 次（不可為 0/永不鎖定） | `-eq 5` | `AtMostNonZero 5` |
+
+      指令碼自身版本號由 `1.0` 提升為 `1.1`（見 `GCB_for_windows11.ps1` 檔頭），此版本號僅代表**本指令碼**的修正版次，與下方 GCB 基準版本無關。
+
+    * **基準版本複核**：本次同時複核 NICS（國家資通安全研究院）目前公告之 Windows 11 GCB 基準版本。本工作階段的網路政策封鎖 `www.nics.nat.gov.tw` 與 `download.nics.nat.gov.tw`（連線回應 403），故改以公開網路搜尋交叉比對官方檔名與發布資訊。確認結果：現行基準仍為 **TWGCB-01-010 v1.0**（中華民國112年12月1日 / 1121201）。搜尋過程中曾出現「v1.1（1141105）」的說法，但**查無任何可驗證、可點擊的官方來源**佐證，判斷為不可靠資訊，故**不予採用**，本專案亦**不**調整 GCB 基準文件版本號。
+
+---
 ## Related projects
 
 * [GCB_for_rockylinux](https://github.com/trionnemesis/GCB_for_rockylinux) — 同系列的 Rocky Linux 政府組態基準自動化檢測與修正指令碼。


### PR DESCRIPTION
## 異動範圍 (Scope)

- `GCB_for_windows11.ps1`：`Check-Set-SecurityPolicy` 新增 `-Comparison` 參數（`Equal` / `AtLeast` / `AtMostNonZero`），並修正帳戶原則檢查項目 TWGCB-01-010-0001、0002、0003、0007 的比對邏輯。指令碼版本 `1.0` → `1.1`。
- `README.md`：新增「變更紀錄」章節，記錄本次修正內容與基準版本複核結果；並於「指令碼擴充說明」補充 `-Comparison` 參數用法。

## 異動原因 (Why)

`Check-Set-SecurityPolicy` 先前一律以完全相等 (`-eq`) 判斷帳戶原則是否合規，但 TWGCB-01-010 對應項目實際規定為「範圍／門檻」而非單一固定值，導致：
1. 已符合、甚至更嚴格的既有設定（例如密碼長度已設為 14、鎖定閾值已設為 3）被誤判為 `NON-COMPLIANT`；
2. 觸發修正後，反而把更嚴格的既有設定**弱化**至門檻值；
3. 未正確處理「0」在部分項目代表「永不過期／永不鎖定」的不合規特殊值。

詳細對照表見 README「變更紀錄」。此問題與邏輯修正方向已在 issue #1 的維運紀錄與既有草稿 PR #3 / #5 中多次提出；本 PR 是在**目前最新 main**（含 2026-07-16 的 LICENSE/README 整併）之上重新套用並驗證此修正，而非沿用 PR #3/#5 已過期、與 main 衝突（`mergeable_state: dirty`）的分支。

## 基準版本複核

本工作階段的網路政策阻擋直接連線 `www.nics.nat.gov.tw`／`download.nics.nat.gov.tw`（回應 403），因此改以公開搜尋交叉比對官方檔名與發布資訊。確認 TWGCB-01-010 現行仍為 **v1.0（中華民國112年12月1日 / 1121201）**，並未發現官方已發布新版本。PR #2 提及之「v1.1（1141105）」查無可驗證來源，判斷為不可靠資訊，本次**未採用**、亦未調整基準版本號。

## 與既有草稿 PR 的關係

建議待本 PR 確認可合併後，將 #3、#5（內容重複、且已與 main 衝突）標記為由本 PR 取代；#2（未經證實的 v1.1 版本聲稱）建議保留觀察、暫不採用。是否關閉上述 PR 由 repo owner 裁決，本次不代為執行。

---
🤖 Generated as part of a scheduled GCB baseline reverification pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_014VfAyFxGr4x8vBzpEDi564)_